### PR TITLE
Consertar bug em teste, adicionar arquivo de configuração em testes

### DIFF
--- a/BRCurtidas.PagSeguro.Tests/BRCurtidas.PagSeguro.Tests.csproj
+++ b/BRCurtidas.PagSeguro.Tests/BRCurtidas.PagSeguro.Tests.csproj
@@ -18,4 +18,10 @@
     <ProjectReference Include="..\BRCurtidas.PagSeguroClient\BRCurtidas.PagSeguro.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/BRCurtidas.PagSeguro.Tests/PagSeguroClientIntegrationTests.cs
+++ b/BRCurtidas.PagSeguro.Tests/PagSeguroClientIntegrationTests.cs
@@ -55,7 +55,7 @@ namespace BRCurtidas.PagSeguro.Tests
             var response = await client.CreateCheckout(request);
 
             response.Code.Should().NotBeNullOrWhiteSpace();
-            response.Date.Should().BeOnOrAfter(requestDate);
+            response.Date.Should().BeOnOrAfter(requestDate.Date);
         }
     }
 }

--- a/BRCurtidas.PagSeguro.Tests/xunit.runner.json
+++ b/BRCurtidas.PagSeguro.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "methodDisplay": "method"
+}

--- a/BRCurtidas.Web.Api.Tests/BRCurtidas.Web.Api.Tests.csproj
+++ b/BRCurtidas.Web.Api.Tests/BRCurtidas.Web.Api.Tests.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="..\BRCurtidas.Web.Api\BRCurtidas.Web.Api.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/BRCurtidas.Web.Api.Tests/xunit.runner.json
+++ b/BRCurtidas.Web.Api.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "methodDisplay": "method"
+}


### PR DESCRIPTION
Com este Pull Request, eu estou consertando um bug no teste de integração do PagSeguro, e também melhorando a exibição dos testes no TestRunner com um arquivo de configuração do Xunit.

O arquivo App.config sozinho não é suficiente para que os nomes fiquem como desejado no .NET Core, necessário também a criação do xunit.runner.json, conforme está nas mudanças deste Pull Request.